### PR TITLE
typos in README: DocType is an error at this position

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ App.PhotosRoute = Ember.Route.extend({
 
 App.PhotoRoute = Ember.Route.extend({
 	model: function(params) {
-		return App.pouch.GET('photo', params.id);
+		return App.pouch.GET(params.id);
 	}
 });
 ```
@@ -154,7 +154,7 @@ export default PhotosRoute;
 ```javascript
 var PhotoRoute = Ember.Route.extend({
 	model: function(params) {
-		return this.pouch.GET('photo', params.id);
+		return this.pouch.GET(params.id);
 	}
 });
 


### PR DESCRIPTION
`App.pouch.GET` does not accept the model type as first parameter. Not a functional correction, but makes the examples functional. It took me a second to figure this out...
