### PR TITLE
Update Pouch references to PouchDB

### DIFF
--- a/lib/ember-pouchdb/storage.js
+++ b/lib/ember-pouchdb/storage.js
@@ -61,7 +61,7 @@ var Storage = Ember.Object.extend({
           }
         });
       };
-      new Pouch(name, options, _createDB);
+      new PouchDB(name, options, _createDB);
     };
 
     return this._newPromise(createDB);
@@ -329,7 +329,7 @@ var Storage = Ember.Object.extend({
           }          
         });
       };
-      Pouch.destroy(dbName, _removeDB);
+      PouchDB.destroy(dbName, _removeDB);
     };
 
     return this._newPromise(removeDB);


### PR DESCRIPTION
As discussed in [PouchDB issue 1079](https://github.com/daleharvey/pouchdb/issues/1079), calls to the PouchDB initialiser are now made with `PouchDB` rather than `Pouch`.
