### PR TITLE
Use new to construct promise; Ember.js pull 3830

### DIFF
--- a/lib/ember-pouchdb/promise_tracker.js
+++ b/lib/ember-pouchdb/promise_tracker.js
@@ -11,7 +11,7 @@ var PromiseTracker = Ember.ArrayProxy.extend({
   },
   newPromise: function(callback) {
     // save a reference to it in the tracker and return a new promise
-    var promise = Ember.RSVP.Promise(callback);
+    var promise = new Ember.RSVP.Promise(callback);
     this.pushObject(promise);
     return promise;
   },


### PR DESCRIPTION
Using `new` on the promise constructor is now required, as mentioned [here](https://github.com/emberjs/ember.js/pull/3830/files#diff-f6860b0357158cfabf3719a563188913R775).
