### PR TITLE
Add missing reference to this

### DIFF
--- a/lib/ember-pouchdb/storage.js
+++ b/lib/ember-pouchdb/storage.js
@@ -288,6 +288,8 @@ var Storage = Ember.Object.extend({
       _id: model.get('id'),
       _rev: model.get('rev')
     };
+    
+    var that = this;
 
     var removeDoc = function(db){
       var promise = that._newPromise(function(resolve, reject){


### PR DESCRIPTION
I couldn’t figure out how to add a test for this, sorry. The PouchDB callback contains a reference to `that` which is never set in the containing closure.
