### PR TITLE
Stop relying on client-side docType in findAll reduce function

### DIFF
--- a/lib/ember-pouchdb/storage.js
+++ b/lib/ember-pouchdb/storage.js
@@ -86,12 +86,13 @@ var Storage = Ember.Object.extend({
     options.docType = docType;
 
     var that = this;
+    var findByDocType;
 
-    var findByDocType = function(doc) {
-      if (doc.docType === options.docType) {
-        emit(doc._id, doc);
-      }
-    };
+    eval("findByDocType = function(doc) { \
+      if (doc.docType === '" + docType + "') { \
+        emit(doc._id, doc); \
+      } \
+    }");
 
     var queryByDocType = function(db){
       var promise = that._newPromise(function(resolve, reject){


### PR DESCRIPTION
Another fix without tests, sorry. I couldn’t get the tests working with a CouchDB instance.

The reduce function in `findAll` isn’t working when PouchDB defers to a CouchDB instance because the `findByDocType` function relies on a client-side variable. I used an `eval` to construct a self-contained `findByDocType`, but maybe there’s a better way?
