### PR TITLE
Update README.md for cdnjs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This library requires PouchDB library to be included in the page before this lib
 * [AMD](https://raw.github.com/taras/ember-pouchdb/master/dist/ember-pouchdb.amd.js)
 
 ```html
-<script src="http://download.pouchdb.com/pouchdb-nightly.js"></script>
+<script src="//cdn.jsdelivr.net/pouchdb/2.2.3/pouchdb.js"></script>
 <script src="https://raw.github.com/taras/ember-pouchdb/master/dist/ember-pouchdb.js"></script>
 ```
 


### PR DESCRIPTION
I think your ember-pouchdb.js script tag will also not work, because the GitHub raw API does not provide the right content-type (last I checked).
